### PR TITLE
Use Docker images from ECR Public, not our vendored repos

### DIFF
--- a/.buildkite/scripts/run_autoformat.sh
+++ b/.buildkite/scripts/run_autoformat.sh
@@ -9,7 +9,7 @@ ROOT=$(git rev-parse --show-toplevel)
 docker run --tty --rm \
   --volume "$ROOT":/repo \
   --workdir /repo \
-  760097843905.dkr.ecr.eu-west-1.amazonaws.com/hashicorp/terraform:light fmt -recursive
+  public.ecr.aws/hashicorp/terraform:light fmt -recursive
 
 # Run the Python autoformatting
 docker run --tty --rm \


### PR DESCRIPTION
For wellcomecollection/platform#5545, which includes a discussion of the benefits.