### PR TITLE
increase r5.large spot price to $0.06

### DIFF
--- a/terraform/buildkite.tf
+++ b/terraform/buildkite.tf
@@ -42,7 +42,7 @@ resource "aws_cloudformation_stack" "buildkite" {
       MinSize = 0
       MaxSize = 20
 
-      SpotPrice    = 0.05
+      SpotPrice    = 0.06
       InstanceType = "r5.large"
 
       BuildkiteQueue = "default"


### PR DESCRIPTION
This is the one that was causing builds to be blocked awaiting an agent.

The actual spot price for an r5.large (i.e. the default agent instance type) is currently 0.0527.