### PR TITLE
Pull some of the Buildkite stack into a module

### DIFF
--- a/terraform/buildkite.tf
+++ b/terraform/buildkite.tf
@@ -1,113 +1,41 @@
-locals {
-  # This is a collection of settings that should be the same for every
-  # instance of our Buildkite stack.
-  common_parameters = {
-    AgentsPerInstance = 1
+module "default" {
+  source = "./stack"
 
-    BuildkiteAgentTokenParameterStorePath = "/aws/reference/secretsmanager/builds/buildkite_agent_key"
+  name       = "buildkite-elasticstack"
+  queue_name = "default"
 
-    InstanceCreationTimeout = "PT5M"
+  ci_agent_role_name = local.ci_agent_role_name
 
-    VpcId           = local.ci_vpc_id
-    Subnets         = join(",", local.ci_vpc_private_subnets)
-    SecurityGroupId = aws_security_group.buildkite.id
+  instance_type = "r5.large"
+  disk_size     = "30 GB"
 
-    CostAllocationTagName  = "aws:createdBy"
-    CostAllocationTagValue = "buildkite-elasticstack"
+  max_workers = 20
 
-    # This tells Buildkite to fetch secrets from our S3 bucket, which
-    # includes the agent hook and SSH key.
-    EnableSecretsPlugin = true
-
-    SecretsBucket = aws_s3_bucket.buildkite_secrets.id
-
-    BuildkiteAgentRelease        = "stable"
-    BuildkiteAgentTimestampLines = false
-
-    RootVolumeName = "/dev/xvda"
-    RootVolumeType = "gp2"
-
-    # We don't have to terminate an agent after a job completes.  We have
-    # an agent hook (see buildkite_agent_hook.sh) which tries to clean up
-    # any state left over from previous jobs, so each instance will be "fresh",
-    # but already have a local cache of Docker images and Scala libraries.
-    BuildkiteTerminateInstanceAfterJob = false
+  extra_parameters = {
+    # This setting tells Buildkite that:
+    #
+    #   - it should turn off an instance if it's idle for 10 minutes (=600s)
+    #   - it should pre-emptively start instances for jobs that are behind
+    #     a 'wait' step
+    #
+    # This is a new feature we got when we updated to v5.7.2 of the
+    # CloudFormation template (22 November 2021).  I'm enabling it to see
+    # if it makes a difference in Scala repos where we do one autoformat step
+    # and then fan out to the main build.
+    #
+    ScaleOutForWaitingJobs = true
+    ScaleInIdlePeriod      = 600
   }
 
-  # This is the price of On-Demand EC2 Instances, which can be obtained
-  # from https://aws.amazon.com/ec2/pricing/on-demand/
-  on_demand_ec2_pricing = {
-    "r5.large"   = 0.125
-    "c5.2xlarge" = 0.34
-    "t3.nano"    = 0.0052
-  }
+  elastic_ci_stack_version = "v5.16.1"
 
-  # We've occasionally seen cases where Buildkite is unable to start new
-  # workers, because the Spot Price gets too high.
-  #
-  # Allow Spot bids up to 10% above the On-Demand price; any more than that
-  # and we should investigate using a mix of On-Demand instances also.
-  instance_information = {
-    for name, price in local.on_demand_ec2_pricing :
-    name => {
-      InstanceType = name
-      SpotPrice    = price * 1.1
-    }
-  }
+  network_config    = local.network_config
+  secrets_bucket_id = aws_s3_bucket.buildkite_secrets.id
 }
 
-resource "aws_cloudformation_stack" "buildkite" {
-  name = "buildkite-elasticstack"
-
-  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
-
-  parameters = merge(
-    local.instance_information["r5.large"],
-    {
-      MinSize = 0
-      MaxSize = 20
-
-      BuildkiteQueue = "default"
-
-      # This setting tells Buildkite that:
-      #
-      #   - it should turn off an instance if it's idle for 10 minutes (=600s)
-      #   - it should pre-emptively start instances for jobs that are behind
-      #     a 'wait' step
-      #
-      # This is a new feature we got when we updated to v5.7.2 of the
-      # CloudFormation template (22 November 2021).  I'm enabling it to see
-      # if it makes a difference in Scala repos where we do one autoformat step
-      # and then fan out to the main build.
-      #
-      ScaleOutForWaitingJobs = true
-      ScaleInIdlePeriod      = 600
-
-      InstanceRoleName = local.ci_agent_role_name
-
-      # Before a job starts, Buildkite will do a disk health check for
-      # free space.  We used to have this set at 25GB, but on days with
-      # lots of builds (and so lots of long-lived agents) we started to
-      # see errors from this health check:
-      #
-      #     Not enough disk space free, cutoff is 5242880 🚨
-      #     Disk health checks failed
-      #
-      # If you see this error again, consider increasing this limit.
-      RootVolumeSize = 30
-
-      # If we don't disable this setting, we get this error when trying to
-      # run Docker containers on the instances:
-      #
-      #     docker: Error response from daemon: cannot share the host's
-      #     network namespace when user namespaces are enabled.
-      #
-      EnableDockerUserNamespaceRemap = false
-    },
-    local.common_parameters
-  )
-
-  template_body = file("${path.module}/buildkite-v5.16.1.yml")
+moved {
+  from = aws_cloudformation_stack.buildkite
+  to   = module.default.aws_cloudformation_stack.buildkite
 }
 
 # This is a separate pool of Buildkite instances specifically meant
@@ -120,54 +48,40 @@ resource "aws_cloudformation_stack" "buildkite" {
 #      agents:
 #        queue: "scala"
 #
-resource "aws_cloudformation_stack" "buildkite_scala" {
-  name = "buildkite-elasticstack-scala"
+module "scala" {
+  source = "./stack"
 
-  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+  name       = "buildkite-elasticstack-scala"
+  queue_name = "scala"
 
-  parameters = merge(
-    local.instance_information["c5.2xlarge"],
-    {
-      BuildkiteQueue = "scala"
+  ci_agent_role_name = local.ci_scala_agent_role_name
 
-      MinSize = 0
-      MaxSize = 60
+  instance_type = "c5.2xlarge"
+  disk_size     = "30 GB"
 
-      # This setting would tell Buildkite to scale out for steps behind wait
-      # steps.
-      #
-      # We don't enable it for nano instances because these are often waiting
-      # behind long-running tasks in the large queue (e.g. build and publish
-      # a Docker image, then deploy it from a nano instance) and the pre-emptively
-      # scaled instances would likely time out before they were used.
-      #
-      ScaleOutForWaitingJobs = false
+  max_workers = 60
 
-      # If we don't disable this setting, we get this error when trying to
-      # run Docker containers on the instances:
-      #
-      #     docker: Error response from daemon: cannot share the host's
-      #     network namespace when user namespaces are enabled.
-      #
-      EnableDockerUserNamespaceRemap = false
+  extra_parameters = {
+    # This setting would tell Buildkite to scale out for steps behind wait
+    # steps.
+    #
+    # We don't enable it for nano instances because these are often waiting
+    # behind long-running tasks in the large queue (e.g. build and publish
+    # a Docker image, then deploy it from a nano instance) and the pre-emptively
+    # scaled instances would likely time out before they were used.
+    #
+    ScaleOutForWaitingJobs = false
+  }
 
-      InstanceRoleName = local.ci_scala_agent_role_name
+  elastic_ci_stack_version = "v5.16.1"
 
-      # Before a job starts, Buildkite will do a disk health check for
-      # free space.  We used to have this set at 25GB, but on days with
-      # lots of builds (and so lots of long-lived agents) we started to
-      # see errors from this health check:
-      #
-      #     Not enough disk space free, cutoff is 5242880 🚨
-      #     Disk health checks failed
-      #
-      # If you see this error again, consider increasing this limit.
-      RootVolumeSize = 30
-    },
-    local.common_parameters
-  )
+  network_config    = local.network_config
+  secrets_bucket_id = aws_s3_bucket.buildkite_secrets.id
+}
 
-  template_body = file("${path.module}/buildkite-v5.16.1.yml")
+moved {
+  from = aws_cloudformation_stack.buildkite_scala
+  to   = module.scala.aws_cloudformation_stack.buildkite
 }
 
 # This is a separate pool of Buildkite instances specifically meant
@@ -184,35 +98,38 @@ resource "aws_cloudformation_stack" "buildkite_scala" {
 #      agents:
 #        queue: "nano"
 #
-resource "aws_cloudformation_stack" "buildkite_nano" {
-  name = "buildkite-elasticstack-nano"
+module "nano" {
+  source = "./stack"
 
-  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+  name       = "buildkite-elasticstack-nano"
+  queue_name = "nano"
 
-  parameters = merge(
-    local.instance_information["t3.nano"],
-    {
-      BuildkiteQueue = "nano"
+  ci_agent_role_name = local.ci_nano_agent_role_name
 
-      MinSize = 0
-      MaxSize = 10
+  instance_type = "t3.nano"
+  disk_size     = "10 GB"
 
-      # This setting would tell Buildkite to scale out for steps behind wait
-      # steps.
-      #
-      # We don't enable it for nano instances because these are often waiting
-      # behind long-running tasks in the large queue (e.g. build and publish
-      # a Docker image, then deploy it from a nano instance) and the pre-emptively
-      # scaled instances would likely time out before they were used.
-      #
-      ScaleOutForWaitingJobs = false
+  max_workers = 10
 
-      InstanceRoleName = local.ci_nano_agent_role_name
+  extra_parameters = {
+    # This setting would tell Buildkite to scale out for steps behind wait
+    # steps.
+    #
+    # We don't enable it for nano instances because these are often waiting
+    # behind long-running tasks in the large queue (e.g. build and publish
+    # a Docker image, then deploy it from a nano instance) and the pre-emptively
+    # scaled instances would likely time out before they were used.
+    #
+    ScaleOutForWaitingJobs = false
+  }
 
-      RootVolumeSize = 10
-    },
-    local.common_parameters
-  )
+  elastic_ci_stack_version = "v5.16.1"
 
-  template_body = file("${path.module}/buildkite-v5.16.1.yml")
+  network_config    = local.network_config
+  secrets_bucket_id = aws_s3_bucket.buildkite_secrets.id
+}
+
+moved {
+  from = aws_cloudformation_stack.buildkite_nano
+  to   = module.nano.aws_cloudformation_stack.buildkite
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,4 +17,10 @@ locals {
 
   account_id = data.aws_caller_identity.current.account_id
   aws_region = data.aws_region.current.name
+
+  network_config = {
+    vpc_id            = local.ci_vpc_id
+    subnets           = local.ci_vpc_private_subnets
+    security_group_id = aws_security_group.buildkite.id
+  }
 }

--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -1,0 +1,51 @@
+
+
+locals {
+
+
+  # This is a collection of settings that should be the same for every
+  # instance of our Buildkite stack.
+  common_parameters = {
+    AgentsPerInstance = 1
+
+    BuildkiteAgentTokenParameterStorePath = "/aws/reference/secretsmanager/builds/buildkite_agent_key"
+
+    InstanceCreationTimeout = "PT5M"
+
+    VpcId           = var.network_config["vpc_id"]
+    Subnets         = join(",", var.network_config["subnets"])
+    SecurityGroupId = var.network_config["security_group_id"]
+
+    CostAllocationTagName  = "aws:createdBy"
+    CostAllocationTagValue = "buildkite-elasticstack"
+
+    # This tells Buildkite to fetch secrets from our S3 bucket, which
+    # includes the agent hook and SSH key.
+    EnableSecretsPlugin = true
+
+    SecretsBucket = var.secrets_bucket_id
+
+    BuildkiteAgentRelease        = "stable"
+    BuildkiteAgentTimestampLines = false
+
+    RootVolumeName = "/dev/xvda"
+    RootVolumeType = "gp2"
+
+    # We don't have to terminate an agent after a job completes.  We have
+    # an agent hook (see buildkite_agent_hook.sh) which tries to clean up
+    # any state left over from previous jobs, so each instance will be "fresh",
+    # but already have a local cache of Docker images and Scala libraries.
+    BuildkiteTerminateInstanceAfterJob = false
+  }
+
+  # This is the price of On-Demand EC2 Instances, which can be obtained
+  # from https://aws.amazon.com/ec2/pricing/on-demand/
+  #
+  # In theory there's a Terraform provider for this, but I couldn't get
+  # it to work: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/pricing_product
+  on_demand_ec2_pricing = {
+    "r5.large"   = 0.125
+    "c5.2xlarge" = 0.34
+    "t3.nano"    = 0.0052
+  }
+}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -1,0 +1,38 @@
+resource "aws_cloudformation_stack" "buildkite" {
+  name = var.name
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+
+  parameters = merge(
+    {
+      MinSize = var.min_workers
+      MaxSize = var.max_workers
+
+      BuildkiteQueue = var.queue_name
+
+      # We've occasionally seen cases where Buildkite is unable to start new
+      # workers, because the Spot Price gets too high.
+      #
+      # Allow Spot bids up to 10% above the On-Demand price; any more than that
+      # and we should investigate using a mix of On-Demand instances also.
+      InstanceType = var.instance_type
+      SpotPrice    = local.on_demand_ec2_pricing[var.instance_type] * 1.1
+
+      InstanceRoleName = var.ci_agent_role_name
+
+      RootVolumeSize = parseint(replace(var.disk_size, " GB", ""), 10)
+
+      # If we don't disable this setting, we get this error when trying to
+      # run Docker containers on the instances:
+      #
+      #     docker: Error response from daemon: cannot share the host's
+      #     network namespace when user namespaces are enabled.
+      #
+      EnableDockerUserNamespaceRemap = false
+    },
+    var.extra_parameters,
+    local.common_parameters
+  )
+
+  template_body = file("${path.module}/../buildkite-${var.elastic_ci_stack_version}.yml")
+}

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -1,0 +1,45 @@
+variable "name" {
+  type = string
+}
+
+variable "queue_name" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "min_workers" {
+  type    = number
+  default = 0
+}
+
+variable "max_workers" {
+  type = number
+}
+
+variable "elastic_ci_stack_version" {
+  type = string
+}
+
+variable "extra_parameters" {}
+
+variable "network_config" {}
+
+variable "ci_agent_role_name" {
+  type = string
+}
+
+variable "disk_size" {
+  type = string
+
+  validation {
+    condition     = can(regex("^\\d+ GB$", var.disk_size))
+    error_message = "The disk_size must be a string like '10 GB' or '20 GB'."
+  }
+}
+
+variable "secrets_bucket_id" {
+  type = string
+}


### PR DESCRIPTION
There's a bunch of repeated configuration, and the CloudFormation interface doesn't always make it clear what we're doing.  This pulls it into a module with a slightly nicer interface, so it should be easier to mix and match Buildkite instance types as we need.

This is a refactor I've been thinking about for a while – I think it makes the top-level config a bit easier to follow.