### PR TITLE
Define our Buildkite pipelines in Terraform

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -25,8 +25,23 @@ provider "registry.terraform.io/buildkite/buildkite" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.54.0"
+  version = "5.16.0"
   hashes = [
-    "h1:CvZ2TNI0ImPJN1xxCCZsrU5mEQXcyfPcEWM7u7tMfPs=",
+    "h1:QJMj+q9X6Idj9suvQV2Kx6U4G+TjJNm6nUS3HA0bgqc=",
+    "zh:0f5926efc6940ef57780e484a70b11807adfaeb097410e152f32bcff7047e08d",
+    "zh:1faa567428bca687ab3bcaf04e1375eff12ad8cbe6d51c5a517f6fe84f53125e",
+    "zh:2c3b33bc3bdcb7e75688c94cd2aac3e6118d05ed04363157ccb807ea2bfe96ac",
+    "zh:2ea04e1024d5c2566016eb048b36e9e3742a45dda4c18de8f3a802aecb02d095",
+    "zh:4be3187c8db8929d8c4adc0de0b0f8184016d1a2dd575a26ac72f0a921e1f70f",
+    "zh:8242b0105d12054a6c3e448ce6f29f45b62ace76dfc22d9dfdef598b1cfab7d1",
+    "zh:9709cccd23795701f725802042b62624ee35d8ff5561c986a4f3f779596756e9",
+    "zh:995f835bc57a86affa5fe2103607a5215c18f2fc124be86fe562703436e90735",
+    "zh:9a7e8557f96d4a7175173181b488904c92165884e84b103b9c3ae6c6637bd22b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ada90d88df7d4a72d5992618ed67780a3fa9f47087ccdfdb9b17190fd5dbfccd",
+    "zh:bdb8b349b5b6ed65e19336753266997dd80ce756a4aae38aa62a38bc76f4d99b",
+    "zh:c8e1c3df6ef7ce1495285f0b38b0520d1c26234f4099d1458e944c0f42e317af",
+    "zh:d6b50845b6a52e7b96575521e7953b6b6ca444a46d25db1ca0c5a7c28055c7ce",
+    "zh:eade126e8ffb323d7777b4ce44acf072a0da5d0581cca5bab983b49d3d7cbd1d",
   ]
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/buildkite/buildkite" {
+  version     = "0.27.0"
+  constraints = "0.27.0"
+  hashes = [
+    "h1:DBg8LEGH1/wjwjHo8r7YxnH6zwLPPNePjl1Rb1k/94s=",
+    "zh:11cae45fe305060c632c9f66a35778366243d8e5bc7080bcfa00f82059b84500",
+    "zh:6c25725948778efe6128170f550862d2a62f6d83a3ce09b4fba96c22910fa503",
+    "zh:6eb9f1533468ebdb889bb7980b1128d7a9ef88ebc66f2d21ecd461e241f0fd8c",
+    "zh:74e8ea5332f8108cdc3c72200ca75425624987fd055c82edf4247fcea8294725",
+    "zh:821552fd12cf1059591d41bce496a98da271760db7d7a1d70318c193356417e1",
+    "zh:88df4b88dad2a35df75a4cac8819d9df7adbab0c0fbbabbb9c6ec0d6f6e51d99",
+    "zh:a4767b069bfa660ffd8958c4ba6eb885c2cae361829db5136740fb8221e6df86",
+    "zh:ab39e18394f68933597ec3d38826f03374d8bd8829be28071913b21f9fd87ea9",
+    "zh:af77eaa17152e220ba87272dc6f0e5ab21149679744c9a0c507f2c59fe4da62b",
+    "zh:bec18c7632a8801cfd096a8b97a69b7f1174f3c3ae1c3a5ced010528a728c60c",
+    "zh:c57c03e724a086b1985d7e3b1574adc0e5bd7beab1eac4852771798706c79288",
+    "zh:c68f2296d64fc1c4f5bd22d9e8c0b671cb3053c4ce22e4d86ff440de49be7741",
+    "zh:d095fa907857140282b41c1fa26409d203d1c03db7e6fec1534e305a20df8edd",
+    "zh:e790c0e6759492edd13c3691457979c0b19c26c1f79f361641ee33e168d3b563",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.54.0"
   hashes = [

--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -53,16 +53,16 @@ data "aws_iam_policy_document" "ci_permissions" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:builds/*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:builds/*",
 
       # Allow BuildKite to get rank cluster credentials so it can run tests
       # https://buildkite.com/wellcomecollection/catalogue-api-rank
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:elasticsearch/rank/*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:elasticsearch/rank/*",
 
       # Allow BuildKite to get Prismic API keys to GET/PUT Prismic Custom Types
       # in the Experience build
       # https://buildkite.com/wellcomecollection/experience
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:prismic-model/ci/*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:prismic-model/ci/*",
     ]
   }
 
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "ci_scala_permissions" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:builds/*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:builds/*",
     ]
   }
 
@@ -158,17 +158,17 @@ data "aws_iam_policy_document" "ci_nano_permissions" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:builds/*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:builds/*",
 
       # Allow BuildKite to get read-only credentials for the pipeline
       # cluster, to help with auto-deployment of the pipeline.
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:elasticsearch/pipeline_storage_*/read_only*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:elasticsearch/pipeline_storage_*/read_only*",
 
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:elasticsearch/pipeline_storage_*/public_host*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:elasticsearch/pipeline_storage_*/public_host*",
 
       # Allow BuildKite to get storage service credentials so it can send
       # test bags in the storage service repo.
-      "arn:aws:secretsmanager:${var.aws_region}:${local.account_id}:secret:buildkite/storage_service*",
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:buildkite/storage_service*",
     ]
   }
 

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -33,6 +33,11 @@ EOF
   # ALlow rebuilds within this pipeline.
   allow_rebuilds = true
 
+  tags = [
+    "managed_in_terraform",
+    "https://github.com/wellcomecollection/buildkite-infrastructure",
+  ]
+
   provider_settings {
     # Trigger builds when code is pushed to GitHub.
     trigger_mode = var.github_trigger_mode

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -40,7 +40,7 @@ EOF
 
   provider_settings {
     # Trigger builds when code is pushed to GitHub.
-    trigger_mode = var.trigger_builds_on_code_changes ? "code" : "none"
+    trigger_mode = var.trigger_builds_on
 
     # Run builds when branches are pushed or pull requests are created.
     build_branches      = true

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -40,7 +40,7 @@ EOF
 
   provider_settings {
     # Trigger builds when code is pushed to GitHub.
-    trigger_mode = var.github_trigger_mode
+    trigger_mode = var.trigger_builds_on_code_changes ? "code" : "none"
 
     # Run builds when branches are pushed or pull requests are created.
     build_branches      = true

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -48,3 +48,16 @@ EOF
     publish_blocked_as_pending = true
   }
 }
+
+resource "buildkite_pipeline_schedule" "schedule" {
+  for_each = {
+    for index, schedule in var.schedules :
+    schedule.label => schedule.cronline
+  }
+
+  pipeline_id = buildkite_pipeline.pipeline.id
+  branch      = buildkite_pipeline.pipeline.default_branch
+
+  label    = each.key
+  cronline = each.value
+}

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -31,7 +31,7 @@ EOF
 
   provider_settings {
     # Trigger builds when code is pushed to GitHub.
-    trigger_mode = "code"
+    trigger_mode = var.github_trigger_mode
 
     # Run builds when branches are pushed or pull requests are created.
     build_branches      = true

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -24,10 +24,10 @@ EOF
   #
   # Similarly, any previous builds that have already started on the same
   # branch will be skipped.
-  skip_intermediate_builds = true
+  skip_intermediate_builds               = true
   skip_intermediate_builds_branch_filter = "!${var.default_branch}"
 
-  cancel_intermediate_builds = true
+  cancel_intermediate_builds               = true
   cancel_intermediate_builds_branch_filter = "!${var.default_branch}"
 
   # ALlow rebuilds within this pipeline.

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -1,6 +1,10 @@
+locals {
+  repository_name = var.repository_name != "" ? var.repository_name : var.name
+}
+
 resource "buildkite_pipeline" "pipeline" {
   name       = var.name
-  repository = "git@github.com:wellcomecollection/${var.repository_name}.git"
+  repository = "git@github.com:wellcomecollection/${local.repository_name}.git"
 
   steps = <<EOF
 steps:

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -41,6 +41,9 @@ EOF
     # the commit and branch already exist.
     skip_pull_request_builds_for_existing_commits = true
 
+    # Cancels running builds for a branch if the branch is deleted.
+    cancel_deleted_branch_builds = true
+
     # Update the status of commits on GitHub.
     publish_commit_status = true
 

--- a/terraform/pipeline/main.tf
+++ b/terraform/pipeline/main.tf
@@ -1,0 +1,50 @@
+resource "buildkite_pipeline" "pipeline" {
+  name       = var.name
+  repository = "git@github.com:wellcomecollection/${var.repository_name}.git"
+
+  steps = <<EOF
+steps:
+  - command: "buildkite-agent pipeline upload ${var.pipeline_filename}"
+    label: ":pipeline:"
+    agents:
+      queue: nano
+EOF
+
+  description = var.description
+
+  default_branch = var.default_branch
+
+  # When a new build is created on a branch, any previous builds that
+  # haven't yet started on the same branch will be automatically marked
+  # as skipped – unless you're on the default branch.
+  #
+  # Similarly, any previous builds that have already started on the same
+  # branch will be skipped.
+  skip_intermediate_builds = true
+  skip_intermediate_builds_branch_filter = "!${var.default_branch}"
+
+  cancel_intermediate_builds = true
+  cancel_intermediate_builds_branch_filter = "!${var.default_branch}"
+
+  # ALlow rebuilds within this pipeline.
+  allow_rebuilds = true
+
+  provider_settings {
+    # Trigger builds when code is pushed to GitHub.
+    trigger_mode = "code"
+
+    # Run builds when branches are pushed or pull requests are created.
+    build_branches      = true
+    build_pull_requests = true
+
+    # Skip creating a build for a pull request if an existing build for
+    # the commit and branch already exist.
+    skip_pull_request_builds_for_existing_commits = true
+
+    # Update the status of commits on GitHub.
+    publish_commit_status = true
+
+    # Show blocked builds in GitHub as 'pending'.
+    publish_blocked_as_pending = true
+  }
+}

--- a/terraform/pipeline/provider.tf
+++ b/terraform/pipeline/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    buildkite = {
+      source = "buildkite/buildkite"
+    }
+  }
+}

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -1,5 +1,5 @@
 variable "name" {
-  type    = string
+  type = string
 }
 
 variable "description" {

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -1,5 +1,5 @@
 variable "name" {
-  type = string
+  type    = string
 }
 
 variable "description" {
@@ -8,7 +8,10 @@ variable "description" {
 }
 
 variable "repository_name" {
-  type = string
+  type    = string
+  default = ""
+
+  description = "The name of the GitHub repository. If omitted, the name will be used."
 }
 
 variable "default_branch" {

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -3,7 +3,8 @@ variable "name" {
 }
 
 variable "description" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "repository_name" {

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  type = string
+}
+
+variable "description" {
+  type = string
+}
+
+variable "repository_name" {
+  type = string
+}
+
+variable "default_branch" {
+  type    = string
+  default = "main"
+}
+
+variable "pipeline_filename" {
+  type = string
+}

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -23,9 +23,9 @@ variable "pipeline_filename" {
   type = string
 }
 
-variable "trigger_builds_on_code_changes" {
-  type    = bool
-  default = true
+variable "trigger_builds_on" {
+  type    = string
+  default = "code"
 }
 
 variable "schedules" {

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -23,9 +23,9 @@ variable "pipeline_filename" {
   type = string
 }
 
-variable "github_trigger_mode" {
-  type    = string
-  default = "code"
+variable "trigger_builds_on_code_changes" {
+  type    = bool
+  default = true
 }
 
 variable "schedules" {

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -18,3 +18,12 @@ variable "default_branch" {
 variable "pipeline_filename" {
   type = string
 }
+
+variable "schedules" {
+  type = list(object({
+    label    = string
+    cronline = string
+  }))
+
+  default = []
+}

--- a/terraform/pipeline/variables.tf
+++ b/terraform/pipeline/variables.tf
@@ -20,6 +20,11 @@ variable "pipeline_filename" {
   type = string
 }
 
+variable "github_trigger_mode" {
+  type    = string
+  default = "code"
+}
+
 variable "schedules" {
   type = list(object({
     label    = string

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -47,3 +47,44 @@ module "storage_service" {
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
+
+module "wc_dot_org_build_plus_test" {
+  source = "./pipeline"
+
+  name        = "wc.org: build + test"
+  description = "Tests for the wellcomecollection.org repository"
+
+  repository_name = "wellcomecollection.org"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "wc_dot_org_deployment" {
+  source = "./pipeline"
+
+  name        = "wc.org: deployment"
+  description = "Deployments for the web apps in the wellcomecollection.org repo"
+
+  repository_name = "wellcomecollection.org"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deployment.yml"
+}
+
+module "wc_dot_org_end_to_end_tests" {
+  source = "./pipeline"
+
+  name        = "wc.org: end-to-end tests"
+  description = "end-to-end tests to verify the website is working correctly"
+
+  repository_name = "wellcomecollection.org"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger by the "deployment" pipeline.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.e2e-universal.yml"
+}

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -37,7 +37,7 @@ module "catalogue_api" {
 module "catalogue_api_deploy_prod" {
   source = "./pipeline"
 
-  name        = "Catalogue API: Deploy prod"
+  name = "Catalogue API: Deploy prod"
 
   repository_name = "catalogue-api"
 
@@ -51,7 +51,7 @@ module "catalogue_api_deploy_prod" {
 module "catalogue_api_deploy_stage" {
   source = "./pipeline"
 
-  name        = "Catalogue API: Deploy stage"
+  name = "Catalogue API: Deploy stage"
 
   repository_name = "catalogue-api"
 
@@ -94,7 +94,7 @@ module "catalogue_pipeline" {
 module "catalogue_pipeline_deploy_pipeline" {
   source = "./pipeline"
 
-  name        = "Catalogue Pipeline: Deploy pipeline"
+  name = "Catalogue Pipeline: Deploy pipeline"
 
   repository_name = "catalogue-pipeline"
 
@@ -108,7 +108,7 @@ module "catalogue_pipeline_deploy_pipeline" {
 module "concepts_pipeline" {
   source = "./pipeline"
 
-  name        = "Concepts Pipeline"
+  name = "Concepts Pipeline"
 
   repository_name = "concepts-pipeline"
 
@@ -119,7 +119,7 @@ module "concepts_pipeline" {
 module "content_api" {
   source = "./pipeline"
 
-  name        = "Content API"
+  name = "Content API"
 
   repository_name = "content-api"
 
@@ -139,7 +139,7 @@ module "developers_dot_wellcomecollection_dot_org" {
 module "elasticsearch_log_forwarder" {
   source = "./pipeline"
 
-  name        = "Elasticsearch Log Forwarder"
+  name = "Elasticsearch Log Forwarder"
 
   repository_name = "elasticsearch-log-forwarder"
 
@@ -150,7 +150,7 @@ module "elasticsearch_log_forwarder" {
 module "fake_sierra" {
   source = "./pipeline"
 
-  name        = "Fake Sierra"
+  name = "Fake Sierra"
 
   repository_name = "fake-sierra"
 
@@ -173,7 +173,7 @@ module "identity" {
 module "identity_deployment" {
   source = "./pipeline"
 
-  name        = "Identity Deployment"
+  name = "Identity Deployment"
 
   repository_name = "identity"
 
@@ -188,7 +188,7 @@ module "identity_deployment" {
 module "identity_deploy_prod" {
   source = "./pipeline"
 
-  name        = "Identity: Deploy Prod"
+  name = "Identity: Deploy Prod"
 
   repository_name = "identity"
 
@@ -203,7 +203,7 @@ module "identity_deploy_prod" {
 module "identity_deploy_stage" {
   source = "./pipeline"
 
-  name        = "Identity: Deploy Stage"
+  name = "Identity: Deploy Stage"
 
   repository_name = "identity"
 
@@ -218,7 +218,7 @@ module "identity_deploy_stage" {
 module "platform_infrastructure" {
   source = "./pipeline"
 
-  name        = "Platform infrastructure"
+  name = "Platform infrastructure"
 
   repository_name = "platform-infrastructure"
 
@@ -229,7 +229,7 @@ module "platform_infrastructure" {
 module "platform_infrastructure_redirects" {
   source = "./pipeline"
 
-  name        = "Platform Infrastructure: Redirects"
+  name = "Platform Infrastructure: Redirects"
 
   repository_name = "platform-infrastructure"
 
@@ -266,7 +266,7 @@ module "prismic_linting" {
 module "rank_cli" {
   source = "./pipeline"
 
-  name        = "Rank CLI"
+  name = "Rank CLI"
 
   repository_name = "rank"
 
@@ -276,7 +276,7 @@ module "rank_cli" {
 module "scala_libraries" {
   source = "./pipeline"
 
-  name        = "Scala Libraries"
+  name = "Scala Libraries"
 
   repository_name = "scala-libs"
 
@@ -386,7 +386,7 @@ module "wc_dot_org_end_to_end_tests" {
 module "wellcome_library_redirects" {
   source = "./pipeline"
 
-  name        = "Wellcome Library: Redirects"
+  name = "Wellcome Library: Redirects"
 
   repository_name = "wellcomelibrary.org"
 
@@ -404,7 +404,7 @@ module "wellcome_library_redirects" {
 module "wellcome_library_repo_tests" {
   source = "./pipeline"
 
-  name        = "Wellcome Library: repo tests"
+  name = "Wellcome Library: repo tests"
 
   repository_name = "wellcomelibrary.org"
 

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -1,3 +1,28 @@
+module "archivematica_infrastructure" {
+  source = "./pipeline"
+
+  name        = "archivematica-infrastructure"
+  description = "Our custom build of Archivematica and associated infrastructure"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "aws_account_infrastructure" {
+  source = "./pipeline"
+
+  name = "aws-account-infrastructure"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "buildkite_infrastructure" {
+  source = "./pipeline"
+
+  name = "buildkite-infrastructure"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
 module "catalogue_api" {
   source = "./pipeline"
 

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -34,6 +34,34 @@ module "catalogue_api" {
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
+module "catalogue_api_deploy_prod" {
+  source = "./pipeline"
+
+  name        = "Catalogue API: Deploy prod"
+
+  repository_name = "catalogue-api"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
+}
+
+module "catalogue_api_deploy_stage" {
+  source = "./pipeline"
+
+  name        = "Catalogue API: Deploy stage"
+
+  repository_name = "catalogue-api"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
+}
+
 module "catalogue_api_rank" {
   source = "./pipeline"
 
@@ -59,6 +87,30 @@ module "catalogue_pipeline" {
   description = "Catalogue Pipeline & adapter services"
 
   repository_name = "catalogue-pipeline"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "catalogue_pipeline_deploy_pipeline" {
+  source = "./pipeline"
+
+  name        = "Catalogue Pipeline: Deploy pipeline"
+
+  repository_name = "catalogue-pipeline"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-pipeline.yml"
+}
+
+module "concepts_pipeline" {
+  source = "./pipeline"
+
+  name        = "Concepts Pipeline"
+
+  repository_name = "concepts-pipeline"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -26,9 +26,8 @@ module "buildkite_infrastructure" {
 module "catalogue_api" {
   source = "./pipeline"
 
-  name        = "Catalogue API"
-  description = "Catalogue API - Search, Items, Snapshot & Requesting services"
-
+  name            = "Catalogue API"
+  description     = "Catalogue API - Search, Items, Snapshot & Requesting services"
   repository_name = "catalogue-api"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -37,37 +36,34 @@ module "catalogue_api" {
 module "catalogue_api_deploy_prod" {
   source = "./pipeline"
 
-  name = "Catalogue API: Deploy prod"
-
+  name            = "Catalogue API: Deploy prod"
   repository_name = "catalogue-api"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
 
 module "catalogue_api_deploy_stage" {
   source = "./pipeline"
 
-  name = "Catalogue API: Deploy stage"
-
+  name            = "Catalogue API: Deploy stage"
   repository_name = "catalogue-api"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
 
 module "catalogue_api_rank" {
   source = "./pipeline"
 
-  name        = "Catalogue API: rank"
-  description = "Run search quality tests against the catalogue API"
-
+  name            = "Catalogue API: rank"
+  description     = "Run search quality tests against the catalogue API"
   repository_name = "catalogue-api"
 
   pipeline_filename = ".buildkite/pipeline.rank.yml"
@@ -83,9 +79,8 @@ module "catalogue_api_rank" {
 module "catalogue_pipeline" {
   source = "./pipeline"
 
-  name        = "Catalogue Pipeline"
-  description = "Catalogue Pipeline & adapter services"
-
+  name            = "Catalogue Pipeline"
+  description     = "Catalogue Pipeline & adapter services"
   repository_name = "catalogue-pipeline"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -94,38 +89,32 @@ module "catalogue_pipeline" {
 module "catalogue_pipeline_deploy_pipeline" {
   source = "./pipeline"
 
-  name = "Catalogue Pipeline: Deploy pipeline"
-
-  repository_name = "catalogue-pipeline"
+  name              = "Catalogue Pipeline: Deploy pipeline"
+  repository_name   = "catalogue-pipeline"
+  pipeline_filename = ".buildkite/pipeline.deploy-pipeline.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-pipeline.yml"
 }
 
 module "concepts_pipeline" {
   source = "./pipeline"
 
-  name = "Concepts Pipeline"
-
+  name            = "Concepts Pipeline"
   repository_name = "concepts-pipeline"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-
 module "content_api" {
   source = "./pipeline"
 
-  name = "Content API"
-
+  name            = "Content API"
   repository_name = "content-api"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
-
 
 module "developers_dot_wellcomecollection_dot_org" {
   source = "./pipeline"
@@ -139,98 +128,83 @@ module "developers_dot_wellcomecollection_dot_org" {
 module "elasticsearch_log_forwarder" {
   source = "./pipeline"
 
-  name = "Elasticsearch Log Forwarder"
-
+  name            = "Elasticsearch Log Forwarder"
   repository_name = "elasticsearch-log-forwarder"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-
 module "fake_sierra" {
   source = "./pipeline"
 
-  name = "Fake Sierra"
-
+  name            = "Fake Sierra"
   repository_name = "fake-sierra"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-
 module "identity" {
   source = "./pipeline"
 
-  name        = "Identity"
-  description = "Identity services for Wellcome Collection users"
-
+  name            = "Identity"
+  description     = "Identity services for Wellcome Collection users"
   repository_name = "identity"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-
 module "identity_deployment" {
   source = "./pipeline"
 
-  name = "Identity Deployment"
-
+  name            = "Identity Deployment"
   repository_name = "identity"
+
+  pipeline_filename = ".buildkite/pipeline.deploy.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy.yml"
 }
-
 
 module "identity_deploy_prod" {
   source = "./pipeline"
 
-  name = "Identity: Deploy Prod"
-
+  name            = "Identity: Deploy Prod"
   repository_name = "identity"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
-
 
 module "identity_deploy_stage" {
   source = "./pipeline"
 
-  name = "Identity: Deploy Stage"
-
+  name            = "Identity: Deploy Stage"
   repository_name = "identity"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
-
 
 module "platform_infrastructure" {
   source = "./pipeline"
 
-  name = "Platform infrastructure"
-
+  name            = "Platform infrastructure"
   repository_name = "platform-infrastructure"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-
 module "platform_infrastructure_redirects" {
   source = "./pipeline"
 
-  name = "Platform Infrastructure: Redirects"
-
+  name            = "Platform Infrastructure: Redirects"
   repository_name = "platform-infrastructure"
 
   pipeline_filename = ".buildkite/pipeline.redirectsTest.yml"
@@ -247,9 +221,8 @@ module "platform_infrastructure_redirects" {
 module "prismic_linting" {
   source = "./pipeline"
 
-  name        = "Prismic linting"
-  description = "Run checks on our Prismic content"
-
+  name            = "Prismic linting"
+  description     = "Run checks on our Prismic content"
   repository_name = "wellcomecollection.org"
 
   pipeline_filename = ".buildkite/pipeline.prismic-linting.yml"
@@ -262,12 +235,10 @@ module "prismic_linting" {
   ]
 }
 
-
 module "rank_cli" {
   source = "./pipeline"
 
-  name = "Rank CLI"
-
+  name            = "Rank CLI"
   repository_name = "rank"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -276,8 +247,7 @@ module "rank_cli" {
 module "scala_libraries" {
   source = "./pipeline"
 
-  name = "Scala Libraries"
-
+  name            = "Scala Libraries"
   repository_name = "scala-libs"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -286,8 +256,7 @@ module "scala_libraries" {
 module "storage_service" {
   source = "./pipeline"
 
-  name = "Storage Service"
-
+  name            = "Storage Service"
   repository_name = "storage-service"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -296,29 +265,27 @@ module "storage_service" {
 module "storage_service_deploy_prod" {
   source = "./pipeline"
 
-  name = "Storage Service: deploy prod"
-
+  name            = "Storage Service: deploy prod"
   repository_name = "storage-service"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
 
 module "storage_service_deploy_stage" {
   source = "./pipeline"
 
-  name = "Storage Service: deploy stage"
-
+  name            = "Storage Service: deploy stage"
   repository_name = "storage-service"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
 
 module "terraform_modules" {
@@ -335,8 +302,7 @@ module "terraform_modules" {
     "terraform-aws-vhs",
   ])
 
-  name = "Terraform module (${each.key})"
-
+  name            = "Terraform module (${each.key})"
   repository_name = each.key
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -345,9 +311,8 @@ module "terraform_modules" {
 module "wc_dot_org_build_plus_test" {
   source = "./pipeline"
 
-  name        = "wc.org: build + test"
-  description = "Tests for the wellcomecollection.org repository"
-
+  name            = "wc.org: build + test"
+  description     = "Tests for the wellcomecollection.org repository"
   repository_name = "wellcomecollection.org"
 
   pipeline_filename = ".buildkite/pipeline.yml"
@@ -356,38 +321,35 @@ module "wc_dot_org_build_plus_test" {
 module "wc_dot_org_deployment" {
   source = "./pipeline"
 
-  name        = "wc.org: deployment"
-  description = "Deployments for the web apps in the wellcomecollection.org repo"
-
+  name            = "wc.org: deployment"
+  description     = "Deployments for the web apps in the wellcomecollection.org repo"
   repository_name = "wellcomecollection.org"
+
+  pipeline_filename = ".buildkite/pipeline.deployment.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.deployment.yml"
 }
 
 module "wc_dot_org_end_to_end_tests" {
   source = "./pipeline"
 
-  name        = "wc.org: end-to-end tests"
-  description = "end-to-end tests to verify the website is working correctly"
-
+  name            = "wc.org: end-to-end tests"
+  description     = "end-to-end tests to verify the website is working correctly"
   repository_name = "wellcomecollection.org"
+
+  pipeline_filename = ".buildkite/pipeline.e2e-universal.yml"
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger by the "deployment" pipeline.
   trigger_builds_on_code_changes = false
-
-  pipeline_filename = ".buildkite/pipeline.e2e-universal.yml"
 }
 
 module "wellcome_library_redirects" {
   source = "./pipeline"
 
-  name = "Wellcome Library: Redirects"
-
+  name            = "Wellcome Library: Redirects"
   repository_name = "wellcomelibrary.org"
 
   pipeline_filename = ".buildkite/pipeline.redirectsTest.yml"
@@ -400,14 +362,11 @@ module "wellcome_library_redirects" {
   ]
 }
 
-
 module "wellcome_library_repo_tests" {
   source = "./pipeline"
 
-  name = "Wellcome Library: repo tests"
-
+  name            = "Wellcome Library: repo tests"
   repository_name = "wellcomelibrary.org"
 
   pipeline_filename = ".buildkite/pipeline.yml"
 }
-

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -26,3 +26,24 @@ module "catalogue_api_rank" {
     }
   ]
 }
+
+module "catalogue_pipeline" {
+  source = "./pipeline"
+
+  name        = "Catalogue Pipeline"
+  description = "Catalogue Pipeline & adapter services"
+
+  repository_name = "catalogue-pipeline"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "storage_service" {
+  source = "./pipeline"
+
+  name = "Storage Service"
+
+  repository_name = "storage-service"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -125,6 +125,27 @@ module "storage_service" {
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
+module "terraform_modules" {
+  source = "./pipeline"
+
+  for_each = toset([
+    "terraform-aws-acm-certificate",
+    "terraform-aws-api-gateway-responses",
+    "terraform-aws-ecs-service",
+    "terraform-aws-lambda",
+    "terraform-aws-secrets",
+    "terraform-aws-sns-topic",
+    "terraform-aws-sqs",
+    "terraform-aws-vhs",
+  ])
+
+  name = "Terraform module (${each.key})"
+
+  repository_name = each.key
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
 module "wc_dot_org_build_plus_test" {
   source = "./pipeline"
 

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -43,7 +43,7 @@ module "catalogue_api_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
@@ -57,7 +57,7 @@ module "catalogue_api_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
@@ -100,7 +100,7 @@ module "catalogue_pipeline_deploy_pipeline" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-pipeline.yml"
 }
@@ -179,7 +179,7 @@ module "identity_deployment" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy.yml"
 }
@@ -194,7 +194,7 @@ module "identity_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
@@ -209,7 +209,7 @@ module "identity_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
@@ -302,7 +302,7 @@ module "storage_service_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
 }
@@ -316,7 +316,7 @@ module "storage_service_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
@@ -363,7 +363,7 @@ module "wc_dot_org_deployment" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.deployment.yml"
 }
@@ -378,7 +378,7 @@ module "wc_dot_org_end_to_end_tests" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger by the "deployment" pipeline.
-  github_trigger_mode = "none"
+  trigger_builds_on_code_changes = false
 
   pipeline_filename = ".buildkite/pipeline.e2e-universal.yml"
 }

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -1,35 +1,15 @@
-resource "buildkite_pipeline" "catalogue_api" {
-  name = "Catalogue API"
-  repository = "git@github.com:wellcomecollection/catalogue-api.git"
-  steps = <<EOF
-steps:
-  - command: "buildkite-agent pipeline upload .buildkite/pipeline.yml"
-    label: ":pipeline:"
-    agents:
-      queue: nano
-EOF
+module "catalogue_api" {
+  source = "./pipeline"
+
+  name        = "Catalogue API"
   description = "Catalogue API - Search, Items, Snapshot & Requesting services"
 
-  default_branch = "main"
+  repository_name = "catalogue-api"
 
-  skip_intermediate_builds = true
-  skip_intermediate_builds_branch_filter = "!main"
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
 
-  allow_rebuilds = true
-
-  cancel_intermediate_builds = true
-  cancel_intermediate_builds_branch_filter = "!main"
-
-  provider_settings {
-    build_pull_requests = true
-    skip_pull_request_builds_for_existing_commits = true
-
-    build_branches = true
-
-    publish_commit_status = true
-
-    publish_blocked_as_pending = true
-
-    trigger_mode = "code"
-  }
+moved {
+  from = buildkite_pipeline.catalogue_api
+  to   = module.catalogue_api.buildkite_pipeline.pipeline
 }

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -115,6 +115,174 @@ module "concepts_pipeline" {
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
+
+module "content_api" {
+  source = "./pipeline"
+
+  name        = "Content API"
+
+  repository_name = "content-api"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+
+module "developers_dot_wellcomecollection_dot_org" {
+  source = "./pipeline"
+
+  name        = "developers.wellcomecollection.org"
+  description = "Build and deploy the documentation for our developer portal"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "elasticsearch_log_forwarder" {
+  source = "./pipeline"
+
+  name        = "Elasticsearch Log Forwarder"
+
+  repository_name = "elasticsearch-log-forwarder"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+
+module "fake_sierra" {
+  source = "./pipeline"
+
+  name        = "Fake Sierra"
+
+  repository_name = "fake-sierra"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+
+module "identity" {
+  source = "./pipeline"
+
+  name        = "Identity"
+  description = "Identity services for Wellcome Collection users"
+
+  repository_name = "identity"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+
+module "identity_deployment" {
+  source = "./pipeline"
+
+  name        = "Identity Deployment"
+
+  repository_name = "identity"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy.yml"
+}
+
+
+module "identity_deploy_prod" {
+  source = "./pipeline"
+
+  name        = "Identity: Deploy Prod"
+
+  repository_name = "identity"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
+}
+
+
+module "identity_deploy_stage" {
+  source = "./pipeline"
+
+  name        = "Identity: Deploy Stage"
+
+  repository_name = "identity"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
+}
+
+
+module "platform_infrastructure" {
+  source = "./pipeline"
+
+  name        = "Platform infrastructure"
+
+  repository_name = "platform-infrastructure"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+
+module "platform_infrastructure_redirects" {
+  source = "./pipeline"
+
+  name        = "Platform Infrastructure: Redirects"
+
+  repository_name = "platform-infrastructure"
+
+  pipeline_filename = ".buildkite/pipeline.redirectsTest.yml"
+
+  schedules = [
+    {
+      label    = "Hourly redirect tests"
+      cronline = "0 * * * *"
+    }
+  ]
+}
+
+
+module "prismic_linting" {
+  source = "./pipeline"
+
+  name        = "Prismic linting"
+  description = "Run checks on our Prismic content"
+
+  repository_name = "wellcomecollection.org"
+
+  pipeline_filename = ".buildkite/pipeline.prismic-linting.yml"
+
+  schedules = [
+    {
+      label    = "every twenty minutes in office hours"
+      cronline = "*/20 8-18 * * 1-5"
+    }
+  ]
+}
+
+
+module "rank_cli" {
+  source = "./pipeline"
+
+  name        = "Rank CLI"
+
+  repository_name = "rank"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "scala_libraries" {
+  source = "./pipeline"
+
+  name        = "Scala Libraries"
+
+  repository_name = "scala-libs"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+
 module "storage_service" {
   source = "./pipeline"
 
@@ -123,6 +291,34 @@ module "storage_service" {
   repository_name = "storage-service"
 
   pipeline_filename = ".buildkite/pipeline.yml"
+}
+
+module "storage_service_deploy_prod" {
+  source = "./pipeline"
+
+  name = "Storage Service: deploy prod"
+
+  repository_name = "storage-service"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-prod.yml"
+}
+
+module "storage_service_deploy_stage" {
+  source = "./pipeline"
+
+  name = "Storage Service: deploy stage"
+
+  repository_name = "storage-service"
+
+  # We don't want to trigger this build from pushes or pull requests --
+  # it's trigger at the end of the "build + test" pipeline on main.
+  github_trigger_mode = "none"
+
+  pipeline_filename = ".buildkite/pipeline.deploy-stage.yml"
 }
 
 module "terraform_modules" {
@@ -186,3 +382,32 @@ module "wc_dot_org_end_to_end_tests" {
 
   pipeline_filename = ".buildkite/pipeline.e2e-universal.yml"
 }
+
+module "wellcome_library_redirects" {
+  source = "./pipeline"
+
+  name        = "Wellcome Library: Redirects"
+
+  repository_name = "wellcomelibrary.org"
+
+  pipeline_filename = ".buildkite/pipeline.redirectsTest.yml"
+
+  schedules = [
+    {
+      label    = "Hourly redirect tests"
+      cronline = "0 * * * *"
+    }
+  ]
+}
+
+
+module "wellcome_library_repo_tests" {
+  source = "./pipeline"
+
+  name        = "Wellcome Library: repo tests"
+
+  repository_name = "wellcomelibrary.org"
+
+  pipeline_filename = ".buildkite/pipeline.yml"
+}
+

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -9,7 +9,20 @@ module "catalogue_api" {
   pipeline_filename = ".buildkite/pipeline.yml"
 }
 
-moved {
-  from = buildkite_pipeline.catalogue_api
-  to   = module.catalogue_api.buildkite_pipeline.pipeline
+module "catalogue_api_rank" {
+  source = "./pipeline"
+
+  name        = "Catalogue API: rank"
+  description = "Run search quality tests against the catalogue API"
+
+  repository_name = "catalogue-api"
+
+  pipeline_filename = ".buildkite/pipeline.rank.yml"
+
+  schedules = [
+    {
+      label    = "Hourly rank tests"
+      cronline = "0 * * * *"
+    }
+  ]
 }

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -1,0 +1,35 @@
+resource "buildkite_pipeline" "catalogue_api" {
+  name = "Catalogue API"
+  repository = "git@github.com:wellcomecollection/catalogue-api.git"
+  steps = <<EOF
+steps:
+  - command: "buildkite-agent pipeline upload .buildkite/pipeline.yml"
+    label: ":pipeline:"
+    agents:
+      queue: nano
+EOF
+  description = "Catalogue API - Search, Items, Snapshot & Requesting services"
+
+  default_branch = "main"
+
+  skip_intermediate_builds = true
+  skip_intermediate_builds_branch_filter = "!main"
+
+  allow_rebuilds = true
+
+  cancel_intermediate_builds = true
+  cancel_intermediate_builds_branch_filter = "!main"
+
+  provider_settings {
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+
+    build_branches = true
+
+    publish_commit_status = true
+
+    publish_blocked_as_pending = true
+
+    trigger_mode = "code"
+  }
+}

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -43,7 +43,7 @@ module "catalogue_api_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "catalogue_api_deploy_stage" {
@@ -56,7 +56,7 @@ module "catalogue_api_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "catalogue_api_rank" {
@@ -95,7 +95,7 @@ module "catalogue_pipeline_deploy_pipeline" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "concepts_pipeline" {
@@ -163,7 +163,7 @@ module "identity_deployment" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "identity_deploy_prod" {
@@ -176,7 +176,7 @@ module "identity_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "identity_deploy_stage" {
@@ -189,7 +189,7 @@ module "identity_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "platform_infrastructure" {
@@ -272,7 +272,7 @@ module "storage_service_deploy_prod" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "storage_service_deploy_stage" {
@@ -285,7 +285,7 @@ module "storage_service_deploy_stage" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "terraform_modules" {
@@ -329,7 +329,7 @@ module "wc_dot_org_deployment" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger at the end of the "build + test" pipeline on main.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "deployment"
 }
 
 module "wc_dot_org_end_to_end_tests" {
@@ -343,7 +343,7 @@ module "wc_dot_org_end_to_end_tests" {
 
   # We don't want to trigger this build from pushes or pull requests --
   # it's trigger by the "deployment" pipeline.
-  trigger_builds_on_code_changes = false
+  trigger_builds_on = "none"
 }
 
 module "wellcome_library_redirects" {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -29,3 +29,16 @@ provider "aws" {
     }
   }
 }
+
+terraform {
+  required_providers {
+    buildkite = {
+      source  = "buildkite/buildkite"
+      version = "0.27.0"
+    }
+  }
+}
+
+provider "buildkite" {
+  organization = "wellcomecollection"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 provider "aws" {
-  region = var.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::${local.platform_account_id}:role/platform-admin"

--- a/terraform/run_terraform.sh
+++ b/terraform/run_terraform.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+AWS_CLI_PROFILE="platform-infrastructure-terraform"
+PLATFORM_DEVELOPER_ARN="arn:aws:iam::760097843905:role/platform-developer"
+
+aws configure set region eu-west-1 --profile $AWS_CLI_PROFILE
+aws configure set role_arn "$PLATFORM_DEVELOPER_ARN" --profile $AWS_CLI_PROFILE
+aws configure set source_profile default --profile $AWS_CLI_PROFILE
+
+export BUILDKITE_API_TOKEN=$(aws secretsmanager get-secret-value \
+  --secret-id builds/github_wecobot/buildkite_api_access_token \
+  --profile "$AWS_CLI_PROFILE" \
+  --output text \
+  --query 'SecretString')
+
+terraform "$@"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,0 @@
-variable "aws_region" {
-  default = "eu-west-1"
-}


### PR DESCRIPTION
Using the Buildkite Terraform provider, this allows us to manage all ~30 pipelines in ~300 lines of Terraform.

I hope this makes it easier to manage pipelines and keep them in sync; the current process of creating new pipelines is annoyingly manual and every pipeline has slightly different settings.