### PR TITLE
Allow CI to assume s3_scala_releases_read_role_arn

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "ci_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
+      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],
@@ -83,6 +84,7 @@ data "aws_iam_policy_document" "ci_scala_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
+      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],
@@ -131,6 +133,7 @@ data "aws_iam_policy_document" "ci_nano_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
+      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,6 +5,7 @@ locals {
   infra_bucket_arn = local.shared_infra["infra_bucket_arn"]
   infra_bucket_id  = local.shared_infra["infra_bucket"]
 
+  s3_scala_releases_read_role_arn = local.platform_accounts["s3_scala_releases_read_role_arn"]
   platform_read_only_role_arn = local.platform_accounts["platform_read_only_role_arn"]
   account_ci_role_arn_map     = local.platform_accounts["ci_role_arn"]
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -6,8 +6,8 @@ locals {
   infra_bucket_id  = local.shared_infra["infra_bucket"]
 
   s3_scala_releases_read_role_arn = local.platform_accounts["s3_scala_releases_read_role_arn"]
-  platform_read_only_role_arn = local.platform_accounts["platform_read_only_role_arn"]
-  account_ci_role_arn_map     = local.platform_accounts["ci_role_arn"]
+  platform_read_only_role_arn     = local.platform_accounts["platform_read_only_role_arn"]
+  account_ci_role_arn_map         = local.platform_accounts["ci_role_arn"]
 
   ci_agent_role_name       = "ci-agent"
   ci_nano_agent_role_name  = "${local.ci_agent_role_name}-nano"


### PR DESCRIPTION
## What does this change?

This change is required to allow Buildkite to assume to s3 read role. This reduces the permissions Buildkite uses when running certain operations. See https://github.com/wellcomecollection/catalogue-api/pull/766 for a discussion of why this is now required.

## How to test

- [x] Can Buildkite perform the same jobs it has before without error (see: https://buildkite.com/wellcomecollection/catalogue-api/builds/2980 for examples of before & after).

## How can we measure success?

This change follows https://github.com/wellcomecollection/catalogue-api/pull/763, and is part of resolving subsequent permissions issues. See:

- https://github.com/wellcomecollection/aws-account-infrastructure/pull/18
- https://github.com/wellcomecollection/catalogue-api/pull/766

> [!NOTE]
> This change is applied.

## Have we considered potential risks?

This changes the permissions available to Buildkite, but practically it reduces the scope of permissions used so long as the S3 read role permissions are not expanded in the future.
