### PR TITLE
Remove pipeline as moved to GHA

### DIFF
--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -254,7 +254,6 @@ module "terraform_modules" {
     "terraform-aws-secrets",
     "terraform-aws-sns-topic",
     "terraform-aws-sqs",
-    "terraform-aws-vhs",
   ])
 
   name            = "Terraform module (${each.key})"


### PR DESCRIPTION
NOT APPLIED
APPLIED 2024-10-24

## What does this change?

Removes terraform-aws-vhs pipeline as the formatting and release workflows are being moved to Github Actions
https://github.com/wellcomecollection/terraform-aws-vhs/pull/21
For context, the formatting was failing in BK as part of this CODEOWNERS PR. Rather than fixing it in BK it was moved to GHA since that was planned anyway

## How to test

Push to a branch of [terraform-aws-vhs](https://github.com/wellcomecollection/terraform-aws-vhs)
The BK pipeline is not running

## How can we measure success?

We can merge the CODEOWNERS PR with all checks passed
GHA reduce the need for extra scripts and docker stuff

## Have we considered potential risks?

Can easily be recreated if necessary
