### PR TITLE
remove pipelines moved to GHA

### DIFF
--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -243,25 +243,6 @@ module "storage_service_deploy_stage" {
   trigger_builds_on = "none"
 }
 
-module "terraform_modules" {
-  source = "./pipeline"
-
-  for_each = toset([
-    "terraform-aws-acm-certificate",
-    "terraform-aws-api-gateway-responses",
-    "terraform-aws-ecs-service",
-    "terraform-aws-lambda",
-    "terraform-aws-secrets",
-    "terraform-aws-sns-topic",
-    "terraform-aws-sqs",
-  ])
-
-  name            = "Terraform module (${each.key})"
-  repository_name = each.key
-
-  pipeline_filename = ".buildkite/pipeline.yml"
-}
-
 module "wc_dot_org_build_plus_test" {
   source = "./pipeline"
 


### PR DESCRIPTION
NOT APPLIED

## What does this change?

Removes terraform_modules pipelines as the formatting and release workflows are being moved to Github Actions
https://github.com/wellcomecollection/platform/issues/5808
For context, the formatting was failing in BK as part of the PRs adding CODEOWNERS files to all repos. Rather than fixing it in BK the workflows are being moved to GHA since that was planned anyway

## How to test

Push to a branch of in any of the repos listed in the above issue
The BK pipeline is not running

## How can we measure success?

We can merge the CODEOWNERS PR with all checks passed
GHA reduce the need for extra scripts and docker stuff

## Have we considered potential risks?

Can easily be recreated if necessary