### PR TITLE
Remove concept pipeline build

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -25,7 +25,6 @@ data "aws_iam_policy_document" "ci_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
-      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],
@@ -84,7 +83,6 @@ data "aws_iam_policy_document" "ci_scala_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
-      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],
@@ -133,7 +131,6 @@ data "aws_iam_policy_document" "ci_nano_permissions" {
     actions = ["sts:AssumeRole"]
     resources = [
       local.platform_read_only_role_arn,
-      local.s3_scala_releases_read_role_arn,
       local.account_ci_role_arn_map["platform"],
       local.account_ci_role_arn_map["catalogue"],
       local.account_ci_role_arn_map["digirati"],

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,8 +5,8 @@ locals {
   infra_bucket_arn = local.shared_infra["infra_bucket_arn"]
   infra_bucket_id  = local.shared_infra["infra_bucket"]
 
-  platform_read_only_role_arn     = local.platform_accounts["platform_read_only_role_arn"]
-  account_ci_role_arn_map         = local.platform_accounts["ci_role_arn"]
+  platform_read_only_role_arn = local.platform_accounts["platform_read_only_role_arn"]
+  account_ci_role_arn_map     = local.platform_accounts["ci_role_arn"]
 
   ci_agent_role_name       = "ci-agent"
   ci_nano_agent_role_name  = "${local.ci_agent_role_name}-nano"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,7 +5,6 @@ locals {
   infra_bucket_arn = local.shared_infra["infra_bucket_arn"]
   infra_bucket_id  = local.shared_infra["infra_bucket"]
 
-  s3_scala_releases_read_role_arn = local.platform_accounts["s3_scala_releases_read_role_arn"]
   platform_read_only_role_arn     = local.platform_accounts["platform_read_only_role_arn"]
   account_ci_role_arn_map         = local.platform_accounts["ci_role_arn"]
 

--- a/terraform/pipelines.tf
+++ b/terraform/pipelines.tf
@@ -98,15 +98,6 @@ module "catalogue_pipeline_deploy_pipeline" {
   trigger_builds_on = "none"
 }
 
-module "concepts_pipeline" {
-  source = "./pipeline"
-
-  name            = "Concepts Pipeline"
-  repository_name = "concepts-pipeline"
-
-  pipeline_filename = ".buildkite/pipeline.yml"
-}
-
 module "content_api" {
   source = "./pipeline"
 


### PR DESCRIPTION
## What does this change?

Removes the concept-pipeline build following https://github.com/wellcomecollection/concepts-pipeline, also removing some now unused IAM roles from other builds.

## How to test

 - [ ] Apply the terraform, does the build go away in Buildkite?

## How can we measure success?

Only keeping the builds we actually run.

## Have we considered potential risks?

Risk should be minimal as this project is no longer in use.
